### PR TITLE
Change order of favourite songs

### DIFF
--- a/spotify2tidal/spotify2tidal.py
+++ b/spotify2tidal/spotify2tidal.py
@@ -82,7 +82,7 @@ class Spotify2Tidal:
 
     def copy_all_saved_spotify_tracks(self):
         """Add all your saved artists to Tidal's favorites."""
-        for track in self.spotify.saved_tracks:
+        for track in reversed(self.spotify.saved_tracks):
             artist_name = track["track"]["artists"][0]["name"]
             track_name = track["track"]["name"]
 


### PR DESCRIPTION
Changed order of spotify favourites to tidal so that it maintains the correct order from spotify. Old order was reversed and newest songs from spotify would be at the end of the list